### PR TITLE
Removed unused p_deleteOlderThan param from CoveoPush.Start()

### DIFF
--- a/coveopush/CoveoPush.py
+++ b/coveopush/CoveoPush.py
@@ -794,12 +794,11 @@ class Push:
             self.UpdateSourceStatus(Constants.SourceStatusType.Idle)
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    def Start(self, p_UpdateStatus: bool = True, p_DeleteOlder: bool = False):
+    def Start(self, p_UpdateStatus: bool = True):
         """
         Start.
         Starts a batch Push call, will set the start ordering Id and will update the status of the source
         :arg p_UpdateStatus: bool (True), if the source status should be updated
-        :arg p_DeleteOlder: bool (False), if older documents should be removed from the index after the new push
         """
 
         self.logger.debug('Start')

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,10 @@ setup(
     author='Wim Nijmeijer',
     author_email='wnijmeijer@coveo.com',
     packages=['coveopush'],
+    install_requires=[
+        'requests',
+        'jsonpickle'
+    ],
     version='0.2',
     description='CoveoPush client',
 )


### PR DESCRIPTION
I simply removed the unused param, instead of handling it, because it's already present in the End() method called after a batch.
Also, I added dependencies to setup.py so that they get installed at the same time as the package.